### PR TITLE
Update CI/CD pipelines to use `uv`

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -24,17 +24,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-      - name: Install dependencies
-        run: |
-          # we are using the -e flag, so that code cov finds the source.
-          # this is not ideal, since installing an editable can technically
-          # differ from a normal install in surprising ways.
-          # pip install -e '.[all]'
       - name: Install the project
-        run: |
-          uv run pytest tests
+        run: uv sync --locked --all-extras --dev
       - name: Test with pytest
         run: |
+          run: uv run --python ${{ matrix.python-version }} pytest tests
           # pip install pytest pytest-cov
           # pip install pytest pytest-cov
           # pytest --cov=pkglite --cov-report=xml

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -18,8 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v7
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ".python-version"
-          arch: "x64"
+          architecture: "x64"
       - name: Install dependencies
         run: |
           pip install -e '.[all]'

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: ".python-version"
-          architecture: "x64"
+          python-version-file: '.python-version'
+          architecture: 'x64'
       - name: Install dependencies
         run: |
           pip install -e '.[all]'

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -18,8 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+      - name: Install uv and set the Python version
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -47,6 +47,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ".python-version"
+          arch: "x64"
       - name: Install dependencies
         run: |
           pip install -e '.[all]'

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -25,13 +25,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Setup UV_PYTHON
-        run: |
-          echo "UV_PYTHON=${{ matrix.python-version }}" >> $GITHUB_ENV
+        run: echo "UV_PYTHON=${{ matrix.python-version }}" >> $GITHUB_ENV
       - name: Install the project
         run: uv sync --locked --all-extras --dev
       - name: Test with pytest
-        run: |
-          run: uv run pytest tests
+        run: uv run pytest tests --cov=pkglite --cov-report=xml
           # pip install pytest pytest-cov
           # pip install pytest pytest-cov
           # pytest --cov=pkglite --cov-report=xml

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -24,11 +24,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+      - name: Setup UV_PYTHON
+        run: |
+          echo "UV_PYTHON=${{ matrix.python-version }}" >> $GITHUB_ENV
       - name: Install the project
         run: uv sync --locked --all-extras --dev
       - name: Test with pytest
         run: |
-          run: uv run --python ${{ matrix.python-version }} pytest tests
+          run: uv run pytest tests
           # pip install pytest pytest-cov
           # pip install pytest pytest-cov
           # pytest --cov=pkglite --cov-report=xml

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -30,9 +30,6 @@ jobs:
         run: uv sync --locked --all-extras --dev
       - name: Test with pytest
         run: uv run pytest tests --cov=pkglite --cov-report=xml
-          # pip install pytest pytest-cov
-          # pip install pytest pytest-cov
-          # pytest --cov=pkglite --cov-report=xml
 
       # - name: Upload coverage reports to Codecov
       #   uses: codecov/codecov-action@v4

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -22,16 +22,22 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
       - name: Install dependencies
         run: |
           # we are using the -e flag, so that code cov finds the source.
           # this is not ideal, since installing an editable can technically
           # differ from a normal install in surprising ways.
-          pip install -e '.[all]'
+          # pip install -e '.[all]'
+      - name: Install the project
+        run: |
+          uv run pytest tests
       - name: Test with pytest
         run: |
-          pip install pytest pytest-cov
-          pytest --cov=pkglite --cov-report=xml
+          # pip install pytest pytest-cov
+          # pip install pytest pytest-cov
+          # pytest --cov=pkglite --cov-report=xml
 
       # - name: Upload coverage reports to Codecov
       #   uses: codecov/codecov-action@v4

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: ".python-version"
       - name: Install dependencies
         run: |
           pip install -e '.[all]'

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -49,10 +49,11 @@ jobs:
         with:
           python-version-file: '.python-version'
           architecture: 'x64'
-      - name: Install dependencies
-        run: |
-          pip install -e '.[all]'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Setup UV_PYTHON
+        run: echo "UV_PYTHON=${{ matrix.python-version }}" >> $GITHUB_ENV
+      - name: Install the project
+        run: uv sync --locked --all-extras --dev
       - name: Test with pytest
-        run: |
-          pip install pytest pytest-cov
-          pytest --cov=pkglite --cov-report=xml
+        run: uv run pytest tests --cov=pkglite --cov-report=xml

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -45,7 +45,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version-file: '.python-version'
-          architecture: 'x64'
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Setup UV_PYTHON

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -19,11 +19,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version-file: '.python-version'
 
       - name: Install uv
-        run: |
-          pip install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Setup UV_PYTHON
+        run:
+          echo "UV_PYTHON=$(cat .python-version)" >> $GITHUB_ENV
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ruff-check.yml
+++ b/.github/workflows/ruff-check.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version-file: '.python-version'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This PR:
- updates test-windows to use .python-version for CI testing
- sets up `uv` and forces it to use version from matrix
- uses `uv` to install the project and run tests

I know it's not an issue, but those changes would help in the long run - @nanxstats, @jasonmvictor